### PR TITLE
feat: Implement taskbar icons and context menus for external apps

### DIFF
--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -68,7 +68,7 @@ export const useWindowManager = (
       removeLaunchedListener?.();
       removeClosedListener?.();
     };
-  }, []);
+  }, [focusApp]);
 
   const getNextPosition = (appWidth: number, appHeight: number) => {
     const desktopWidth = desktopRef.current?.clientWidth || window.innerWidth;
@@ -150,7 +150,9 @@ export const useWindowManager = (
         }
       }
 
-      const instanceId = `${appDef.id}-${Date.now()}`;
+      // This is an internal app, so we can cast AppDefinition
+      const internalAppDef = appDef as AppDefinition;
+      const instanceId = `${internalAppDef.id}-${Date.now()}`;
       const newZIndex = nextZIndex + 1;
       setNextZIndex(newZIndex);
 
@@ -158,22 +160,22 @@ export const useWindowManager = (
       const defaultHeight = appDef.defaultSize?.height || DEFAULT_WINDOW_HEIGHT;
 
       const newApp: OpenApp = {
-        ...appDef,
-        icon: appDef.icon,
+        ...internalAppDef,
+        icon: internalAppDef.icon,
         instanceId,
         zIndex: newZIndex,
         position: getNextPosition(defaultWidth, defaultHeight),
         size: {width: defaultWidth, height: defaultHeight},
         isMinimized: false,
         isMaximized: false,
-        title: appDef.name,
+        title: internalAppDef.name,
         initialData: initialData,
       };
 
       setOpenApps(currentOpenApps => [...currentOpenApps, newApp]);
       setActiveAppInstanceId(instanceId);
     },
-    [appDefinitions, nextZIndex, openApps],
+    [appDefinitions, nextZIndex, openApps, focusApp, toggleMinimizeApp],
   );
 
   const focusApp = useCallback(


### PR DESCRIPTION
This commit introduces the functionality for external applications to be represented on the custom taskbar. It also adds a right-click context menu to these icons with options for window management and pinning.

Key changes:
- Establishes a two-way IPC channel between the main and renderer processes.
- The main process now notifies the renderer when an external app is launched (`app-launched`) and when it closes (`app-closed`), including the process ID.
- The `useWindowManager` hook in the renderer now listens for these events and updates the `openApps` state accordingly, ensuring the UI reflects the actual running applications.
- The `Taskbar` component has been updated to render icons for all open apps (internal and external) and includes a right-click context menu.
- The context menu provides options to 'Minimize'/'Restore', 'Maximize', and 'Close' the application, hooking into the existing window management functions.
- A 'Pin to taskbar'/'Unpin from taskbar' feature is included, with a mocked implementation for toggling the pin state.
- React Hooks dependencies in `useWindowManager` were corrected to prevent stale closures, fixing a potential runtime issue.
- Various type definitions and component props were updated to support this new functionality, and associated type errors were fixed.