### PR TITLE
feat: Implement Taskbar Icon and Context Menu

### DIFF
--- a/window/App.tsx
+++ b/window/App.tsx
@@ -24,6 +24,9 @@ const App: React.FC = () => {
     updateAppPosition,
     updateAppSize,
     updateAppTitle,
+    pinnedAppIDs,
+    pinApp,
+    unpinApp,
   } = useWindowManager(desktopRef);
 
   const [isStartMenuOpen, setIsStartMenuOpen] = useState<boolean>(false);
@@ -156,20 +159,31 @@ const App: React.FC = () => {
                 openApps={openApps}
                 activeAppInstanceId={activeAppInstanceId}
                 onToggleStartMenu={toggleStartMenu}
-                onAppIconClick={(appId, instanceId) => {
+                onAppIconClick={(appDef, instanceId) => {
                   if (instanceId) {
                     const app = openApps.find(a => a.instanceId === instanceId);
                     if (app?.isMinimized) {
-                      toggleMinimizeApp(instanceId);
+                      // If the app is minimized, clicking its icon should restore and focus it.
+                      toggleMinimizeApp(instanceId); // This also focuses the app
                     } else if (activeAppInstanceId !== instanceId) {
+                      // If the app is open but not active, clicking its icon should focus it.
                       focusApp(instanceId);
                     } else {
+                      // If the app is already active, clicking its icon should minimize it.
                       toggleMinimizeApp(instanceId);
                     }
                   } else {
-                    openApp(appId);
+                    // If the app is not open, clicking its icon should open it.
+                    openApp(appDef);
                   }
                 }}
+                pinnedAppIDs={pinnedAppIDs}
+                pinApp={pinApp}
+                unpinApp={unpinApp}
+                closeApp={closeApp}
+                openApp={openApp}
+                minimizeApp={toggleMinimizeApp}
+                maximizeApp={toggleMaximizeApp}
               />
             </>
           )}

--- a/window/components/StartMenu.tsx
+++ b/window/components/StartMenu.tsx
@@ -1,10 +1,11 @@
 import React, {useState, useMemo, useContext} from 'react';
-import {DiscoveredAppDefinition, AppContext} from '../contexts/AppContext';
+import {AppContext} from '../contexts/AppContext';
 import Icon from './icon';
 import {useTheme} from '../theme';
+import {AppDefinition} from '../types';
 
 interface StartMenuProps {
-  onOpenApp: (app: DiscoveredAppDefinition) => void;
+  onOpenApp: (app: AppDefinition) => void;
   onClose: () => void;
 }
 
@@ -14,11 +15,11 @@ const StartMenu: React.FC<StartMenuProps> = ({onOpenApp, onClose}) => {
   const {theme} = useTheme();
 
   const pinnedApps = useMemo(
-    () => apps.filter(app => app.isPinned).slice(0, 12),
+    () => apps.filter(app => app.isPinnedToTaskbar).slice(0, 12),
     [apps],
   );
   const recommendedApps = useMemo(
-    () => apps.filter(app => !app.isPinned).slice(0, 6),
+    () => apps.filter(app => !app.isPinnedToTaskbar).slice(0, 6),
     [apps],
   );
   const sortedApps = useMemo(
@@ -160,7 +161,7 @@ const StartMenu: React.FC<StartMenuProps> = ({onOpenApp, onClose}) => {
           <button
             title="Settings"
             onClick={() => {
-              const settingsApp = apps.find(app => app.appId === 'settings');
+              const settingsApp = apps.find(app => app.id === 'settings');
               if (settingsApp) onOpenApp(settingsApp);
               onClose();
             }}

--- a/window/components/Taskbar.tsx
+++ b/window/components/Taskbar.tsx
@@ -1,15 +1,24 @@
 import React, {useState, useEffect, useContext, useMemo} from 'react';
-import {OpenApp} from '../types';
+import {OpenApp, AppDefinition} from '../types';
 import {DiscoveredAppDefinition, AppContext} from '../contexts/AppContext';
 import {TASKBAR_HEIGHT} from '../constants';
 import {useTheme} from '../theme';
 import Icon from './icon';
+import ContextMenu from './ContextMenu';
+import {buildTaskbarContextMenu} from './taskbar/right-click';
 
 interface TaskbarProps {
   openApps: OpenApp[];
   activeAppInstanceId: string | null;
   onToggleStartMenu: () => void;
-  onAppIconClick: (app: DiscoveredAppDefinition, instanceId?: string) => void;
+  onAppIconClick: (app: AppDefinition, instanceId?: string) => void;
+  pinnedAppIDs: string[];
+  pinApp: (appId: string) => void;
+  unpinApp: (appId: string) => void;
+  closeApp: (instanceId: string) => void;
+  minimizeApp: (instanceId: string) => void;
+  maximizeApp: (instanceId: string) => void;
+  openApp: (appId: string | AppDefinition) => void;
 }
 
 const Taskbar: React.FC<TaskbarProps> = ({
@@ -17,10 +26,22 @@ const Taskbar: React.FC<TaskbarProps> = ({
   activeAppInstanceId,
   onToggleStartMenu,
   onAppIconClick,
+  pinnedAppIDs,
+  pinApp,
+  unpinApp,
+  closeApp,
+  minimizeApp,
+  maximizeApp,
+  openApp,
 }) => {
   const {apps: discoveredApps} = useContext(AppContext);
   const [currentTime, setCurrentTime] = useState(new Date());
   const {theme} = useTheme();
+  const [contextMenu, setContextMenu] = useState<{
+    x: number;
+    y: number;
+    items: any[];
+  } | null>(null);
 
   useEffect(() => {
     const timerId = setInterval(() => setCurrentTime(new Date()), 1000);
@@ -34,16 +55,27 @@ const Taskbar: React.FC<TaskbarProps> = ({
     >();
     const openAppMap = new Map(openApps.map(app => [app.id, app]));
 
-    const pinnedApps = discoveredApps.filter(app => app.isPinned);
+    // ---
+    // STEP 1: Add pinned applications to the taskbar.
+    // ---
+    const pinnedApps = discoveredApps.filter(
+      app => (app as any).isPinnedToTaskbar,
+    );
     pinnedApps.forEach(appDef => {
-      const key = appDef.appId || appDef.path!;
+      // Use the app's unique ID as the key.
+      const key = (appDef as any).id;
       items.set(key, {appDef, instance: openAppMap.get(key)});
     });
 
+    // ---
+    // STEP 2: Add any open applications that are not already pinned.
+    // ---
     openApps.forEach(openApp => {
       const key = openApp.id;
       if (!items.has(key)) {
-        const appDef = discoveredApps.find(app => app.appId === key);
+        // Find the corresponding app definition. The `openApp` object itself
+        // is an `AppDefinition`, but we look in `discoveredApps` to be consistent.
+        const appDef = discoveredApps.find(app => (app as any).id === key);
         if (appDef) {
           items.set(key, {appDef, instance: openApp});
         }
@@ -53,62 +85,119 @@ const Taskbar: React.FC<TaskbarProps> = ({
     return Array.from(items.values());
   }, [discoveredApps, openApps]);
 
+  const handleContextMenu = (
+    e: React.MouseEvent,
+    appDef: AppDefinition,
+    instance?: OpenApp,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const isPinned = pinnedAppIDs.includes(appDef.id);
+    const isRunning = !!instance;
+
+    const menuItems = buildTaskbarContextMenu({
+      app: appDef,
+      instanceId: instance?.instanceId,
+      isPinned,
+      isRunning,
+      pinApp,
+      unpinApp,
+      closeApp,
+      minimizeApp,
+      maximizeApp,
+      openApp,
+    });
+
+    setContextMenu({x: e.clientX, y: e.clientY, items: menuItems});
+  };
+
+  useEffect(() => {
+    const handleClickOutside = () => setContextMenu(null);
+    if (contextMenu) {
+      document.addEventListener('click', handleClickOutside);
+    }
+    return () => document.removeEventListener('click', handleClickOutside);
+  }, [contextMenu]);
+
   return (
-    <div
-      className={`flex items-center justify-between px-4 fixed bottom-0 left-0 right-0 z-50 ${theme.taskbar.background} ${theme.taskbar.textColor}`}
-      style={{height: `${TASKBAR_HEIGHT}px`}}
-    >
-      <div className="flex-1 flex justify-center items-center h-full">
-        <div className="flex items-center space-x-2 h-full">
-          <button
-            onClick={onToggleStartMenu}
-            className={`taskbar-start-button p-2 rounded h-full flex items-center ${theme.taskbar.buttonHover}`}
-            aria-label="Start Menu"
-          >
-            <Icon iconName="start" className="w-5 h-5 text-blue-400" />
-          </button>
+    <>
+      <div
+        className={`flex items-center justify-between px-4 fixed bottom-0 left-0 right-0 z-50 ${theme.taskbar.background} ${theme.taskbar.textColor}`}
+        style={{height: `${TASKBAR_HEIGHT}px`}}
+        onContextMenu={e => e.preventDefault()} // Prevent context menu on the taskbar itself
+      >
+        <div className="flex-1 flex justify-center items-center h-full">
+          <div className="flex items-center space-x-2 h-full">
+            <button
+              onClick={onToggleStartMenu}
+              className={`taskbar-start-button p-2 rounded h-full flex items-center ${theme.taskbar.buttonHover}`}
+              aria-label="Start Menu"
+            >
+              <Icon iconName="start" className="w-5 h-5 text-blue-400" />
+            </button>
 
-          {taskbarItems.map(({appDef, instance}) => {
-            const isActive =
-              instance?.instanceId === activeAppInstanceId &&
-              !instance?.isMinimized;
-            const isMinimized = instance?.isMinimized;
-            const isOpen = !!instance;
+            {taskbarItems.map(({appDef, instance}) => {
+              const isActive =
+                instance?.instanceId === activeAppInstanceId &&
+                !instance?.isMinimized;
+              const isMinimized = instance?.isMinimized;
+              const isOpen = !!instance;
 
-            return (
-              <button
-                key={appDef.id}
-                onClick={() => onAppIconClick(appDef, instance?.instanceId)}
-                className={`p-2 rounded h-[calc(100%-8px)] flex items-center relative transition-colors duration-150 ease-in-out
-                            ${isActive ? theme.taskbar.activeButton : theme.taskbar.buttonHover}
-                            ${isMinimized ? 'opacity-70' : ''}`}
-                title={appDef.name}
-              >
-                <Icon iconName={appDef.icon} className="w-5 h-5" isSmall />
-                {isOpen && (
-                  <span
-                    className={`absolute bottom-0 left-1/2 transform -translate-x-1/2 w-4 h-1 rounded-t-sm
-                                  ${isActive ? theme.taskbar.activeIndicator : isMinimized ? 'bg-gray-400' : 'bg-gray-500'}`}
-                  ></span>
-                )}
-              </button>
-            );
-          })}
+              return (
+                <button
+                  key={appDef.id}
+                  onClick={() =>
+                    onAppIconClick(
+                      appDef as AppDefinition,
+                      instance?.instanceId,
+                    )
+                  }
+                  onContextMenu={e =>
+                    handleContextMenu(e, appDef as AppDefinition, instance)
+                  }
+                  className={`p-2 rounded h-[calc(100%-8px)] flex items-center relative transition-colors duration-150 ease-in-out
+                              ${isActive ? theme.taskbar.activeButton : theme.taskbar.buttonHover}
+                              ${isMinimized ? 'opacity-70' : ''}`}
+                  title={appDef.name}
+                >
+                  <Icon iconName={appDef.icon} className="w-5 h-5" isSmall />
+                  {isOpen && (
+                    <span
+                      className={`absolute bottom-0 left-1/2 transform -translate-x-1/2 w-4 h-1 rounded-t-sm
+                                    ${isActive ? theme.taskbar.activeIndicator : isMinimized ? 'bg-gray-400' : 'bg-gray-500'}`}
+                    ></span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex items-center space-x-3 text-xs">
+          <div>
+            {currentTime.toLocaleTimeString([], {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}
+          </div>
+          <div>
+            {currentTime.toLocaleDateString([], {
+              month: 'short',
+              day: 'numeric',
+            })}
+          </div>
         </div>
       </div>
-
-      <div className="flex items-center space-x-3 text-xs">
-        <div>
-          {currentTime.toLocaleTimeString([], {
-            hour: '2-digit',
-            minute: '2-digit',
-          })}
-        </div>
-        <div>
-          {currentTime.toLocaleDateString([], {month: 'short', day: 'numeric'})}
-        </div>
-      </div>
-    </div>
+      {contextMenu && (
+        <ContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          items={contextMenu.items}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </>
   );
 };
 

--- a/window/components/taskbar/right-click/close.ts
+++ b/window/components/taskbar/right-click/close.ts
@@ -1,0 +1,6 @@
+export const handleCloseApp = (
+  closeApp: (instanceId: string) => void,
+  instanceId: string,
+) => {
+  closeApp(instanceId);
+};

--- a/window/components/taskbar/right-click/index.ts
+++ b/window/components/taskbar/right-click/index.ts
@@ -1,0 +1,83 @@
+import {AppDefinition, OpenApp} from '../../../types';
+import {ContextMenuItem} from '../../ContextMenu';
+import {handleCloseApp} from './close';
+import {handleTogglePin} from './pin';
+import {handleMinimizeApp} from './minimize';
+import {handleMaximizeApp} from './maximize';
+
+export interface TaskbarMenuBuilderContext {
+  app: AppDefinition | OpenApp;
+  instanceId?: string;
+  isPinned: boolean;
+  isRunning: boolean;
+  pinApp: (appId: string) => void;
+  unpinApp: (appId: string) => void;
+  closeApp: (instanceId: string) => void;
+  minimizeApp: (instanceId: string) => void;
+  maximizeApp: (instanceId: string) => void;
+  openApp: (appId: string) => void;
+}
+
+export const buildTaskbarContextMenu = (
+  context: TaskbarMenuBuilderContext,
+): ContextMenuItem[] => {
+  const {
+    app,
+    instanceId,
+    isPinned,
+    isRunning,
+    pinApp,
+    unpinApp,
+    closeApp,
+    minimizeApp,
+    maximizeApp,
+    openApp,
+  } = context;
+
+  const menuItems: ContextMenuItem[] = [];
+
+  // If the app is running, add window management options
+  if (isRunning && instanceId) {
+    // We can add more options like "Move", "Size" later if needed.
+    menuItems.push({
+      type: 'item',
+      label: 'Maximize',
+      onClick: () => handleMaximizeApp(maximizeApp, instanceId),
+    });
+    menuItems.push({
+      type: 'item',
+      label: 'Minimize',
+      onClick: () => handleMinimizeApp(minimizeApp, instanceId),
+    });
+    menuItems.push({type: 'separator'});
+  }
+
+  // Add the option to open a new instance of the app
+  // (This could be more complex, e.g., checking if the app supports multiple instances)
+  menuItems.push({
+    type: 'item',
+    label: app.name,
+    onClick: () => openApp(app.id),
+    disabled: true, // Placeholder, as we don't have a good icon for this yet
+  });
+
+  menuItems.push({type: 'separator'});
+
+  // Add Pin/Unpin option
+  menuItems.push({
+    type: 'item',
+    label: isPinned ? 'Unpin from taskbar' : 'Pin to taskbar',
+    onClick: () => handleTogglePin(app.id, isPinned, pinApp, unpinApp),
+  });
+
+  // If the app is running, add the close option
+  if (isRunning && instanceId) {
+    menuItems.push({
+      type: 'item',
+      label: 'Close window',
+      onClick: () => handleCloseApp(closeApp, instanceId),
+    });
+  }
+
+  return menuItems;
+};

--- a/window/components/taskbar/right-click/maximize.ts
+++ b/window/components/taskbar/right-click/maximize.ts
@@ -1,0 +1,6 @@
+export const handleMaximizeApp = (
+  maximizeApp: (instanceId: string) => void,
+  instanceId: string,
+) => {
+  maximizeApp(instanceId);
+};

--- a/window/components/taskbar/right-click/minimize.ts
+++ b/window/components/taskbar/right-click/minimize.ts
@@ -1,0 +1,6 @@
+export const handleMinimizeApp = (
+  minimizeApp: (instanceId: string) => void,
+  instanceId: string,
+) => {
+  minimizeApp(instanceId);
+};

--- a/window/components/taskbar/right-click/pin.ts
+++ b/window/components/taskbar/right-click/pin.ts
@@ -1,0 +1,12 @@
+export const handleTogglePin = (
+  appId: string,
+  isPinned: boolean,
+  pinApp: (appId: string) => void,
+  unpinApp: (appId: string) => void,
+) => {
+  if (isPinned) {
+    unpinApp(appId);
+  } else {
+    pinApp(appId);
+  }
+};

--- a/window/contexts/AppContext.tsx
+++ b/window/contexts/AppContext.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 // This definition represents the structure of the JSON data in our .app files,
 // which is discovered and served by the backend.
+import {AppDefinition} from '../types';
+
+// This definition represents the structure of the JSON data in our .app files,
+// which is discovered and served by the backend.
 export interface DiscoveredAppDefinition {
   id: string; // filename, e.g., "Notebook.app"
   name: string;
@@ -13,7 +17,7 @@ export interface DiscoveredAppDefinition {
 }
 
 export interface AppContextType {
-  apps: DiscoveredAppDefinition[];
+  apps: AppDefinition[];
 }
 
 // Provide a default value for the context


### PR DESCRIPTION
This commit introduces a functional taskbar that displays icons for both running and pinned applications.

- Adds state management for pinned applications to `useWindowManager`, with persistence to `localStorage`.
- Implements a right-click context menu for taskbar icons with options to Maximize, Minimize, Close, and Pin/Unpin applications.
- Creates a new modular structure for taskbar context menu actions under `window/components/taskbar/right-click/`.
- Fixes a bug in `Taskbar.tsx` where open applications were not being displayed due to an incorrect property lookup.
- Refactors related components (`App.tsx`, `StartMenu.tsx`) to support the new pinning and window management functionality, and clarifies the application type definitions in `AppContext.tsx`.