### PR TITLE
feat: Implement Taskbar with Pinning and Context Menus

### DIFF
--- a/window/App.tsx
+++ b/window/App.tsx
@@ -159,29 +159,12 @@ const App: React.FC = () => {
                 openApps={openApps}
                 activeAppInstanceId={activeAppInstanceId}
                 onToggleStartMenu={toggleStartMenu}
-                onAppIconClick={(appDef, instanceId) => {
-                  if (instanceId) {
-                    const app = openApps.find(a => a.instanceId === instanceId);
-                    if (app?.isMinimized) {
-                      // If the app is minimized, clicking its icon should restore and focus it.
-                      toggleMinimizeApp(instanceId); // This also focuses the app
-                    } else if (activeAppInstanceId !== instanceId) {
-                      // If the app is open but not active, clicking its icon should focus it.
-                      focusApp(instanceId);
-                    } else {
-                      // If the app is already active, clicking its icon should minimize it.
-                      toggleMinimizeApp(instanceId);
-                    }
-                  } else {
-                    // If the app is not open, clicking its icon should open it.
-                    openApp(appDef);
-                  }
-                }}
                 pinnedAppIDs={pinnedAppIDs}
                 pinApp={pinApp}
                 unpinApp={unpinApp}
                 closeApp={closeApp}
                 openApp={openApp}
+                focusApp={focusApp}
                 minimizeApp={toggleMinimizeApp}
                 maximizeApp={toggleMaximizeApp}
               />

--- a/window/components/Taskbar.tsx
+++ b/window/components/Taskbar.tsx
@@ -11,7 +11,6 @@ interface TaskbarProps {
   openApps: OpenApp[];
   activeAppInstanceId: string | null;
   onToggleStartMenu: () => void;
-  onAppIconClick: (app: AppDefinition, instanceId?: string) => void;
   pinnedAppIDs: string[];
   pinApp: (appId: string) => void;
   unpinApp: (appId: string) => void;
@@ -19,13 +18,13 @@ interface TaskbarProps {
   minimizeApp: (instanceId: string) => void;
   maximizeApp: (instanceId: string) => void;
   openApp: (appId: string | AppDefinition) => void;
+  focusApp: (instanceId: string) => void;
 }
 
 const Taskbar: React.FC<TaskbarProps> = ({
   openApps,
   activeAppInstanceId,
   onToggleStartMenu,
-  onAppIconClick,
   pinnedAppIDs,
   pinApp,
   unpinApp,
@@ -33,6 +32,7 @@ const Taskbar: React.FC<TaskbarProps> = ({
   minimizeApp,
   maximizeApp,
   openApp,
+  focusApp,
 }) => {
   const {apps: discoveredApps} = useContext(AppContext);
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -74,6 +74,25 @@ const Taskbar: React.FC<TaskbarProps> = ({
 
     return Array.from(items.values());
   }, [pinnedAppIDs, openApps, discoveredApps]);
+
+  const handleAppIconClick = (appDef: AppDefinition, instance?: OpenApp) => {
+    if (instance) {
+      const app = instance;
+      if (app.isMinimized) {
+        // If the app is minimized, clicking its icon should restore and focus it.
+        minimizeApp(instance.instanceId); // This also focuses the app
+      } else if (activeAppInstanceId !== instance.instanceId) {
+        // If the app is open but not active, clicking its icon should focus it.
+        focusApp(instance.instanceId);
+      } else {
+        // If the app is already active, clicking its icon should minimize it.
+        minimizeApp(instance.instanceId);
+      }
+    } else {
+      // If the app is not open, clicking its icon should open it.
+      openApp(appDef);
+    }
+  };
 
   const handleContextMenu = (
     e: React.MouseEvent,
@@ -137,12 +156,7 @@ const Taskbar: React.FC<TaskbarProps> = ({
               return (
                 <button
                   key={appDef.id}
-                  onClick={() =>
-                    onAppIconClick(
-                      appDef as AppDefinition,
-                      instance?.instanceId,
-                    )
-                  }
+                  onClick={() => handleAppIconClick(appDef, instance)}
                   onContextMenu={e =>
                     handleContextMenu(e, appDef as AppDefinition, instance)
                   }


### PR DESCRIPTION
This commit introduces a functional taskbar that displays icons for both running and pinned applications, and allows them to be managed via a right-click context menu.

It also includes fixes for two follow-up bugs:
1. Default-pinned apps could not be unpinned.
2. Pinned-but-closed apps would not launch on click.

Key changes:
- Adds robust state management for pinned applications to `useWindowManager`, with persistence to `localStorage`. The user's choices are now the source of truth after the initial run.
- Implements a right-click context menu for taskbar icons with options to Maximize, Minimize, Close, and Pin/Unpin applications.
- Creates a new modular structure for taskbar context menu actions under `window/components/taskbar/right-click/`.
- Refactors the click handling logic into the `Taskbar` component, making it more self-contained and fixing the launch bug.
- Fixes an initial bug in `Taskbar.tsx` where open applications were not being displayed due to an incorrect property lookup.
- Clarifies application type definitions in `AppContext.tsx` to improve type safety.