### PR TITLE
feat: Implement Taskbar with Pinning and Context Menus

### DIFF
--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -207,19 +207,28 @@ export const useWindowManager = (
 
   const closeApp = useCallback(
     (instanceId: string) => {
-      setOpenApps(prev => prev.filter(app => app.instanceId !== instanceId));
+      const appToClose = openApps.find(app => app.instanceId === instanceId);
+      if (!appToClose) return;
+
+      const updatedOpenApps = openApps.filter(
+        app => app.instanceId !== instanceId,
+      );
+      setOpenApps(updatedOpenApps);
+
       if (activeAppInstanceId === instanceId) {
-        const remainingApps = openApps.filter(
-          app => app.instanceId !== instanceId,
-        );
-        const nextActiveApp =
-          remainingApps.length > 0
-            ? remainingApps[remainingApps.length - 1].instanceId
-            : null;
-        setActiveAppInstanceId(nextActiveApp);
+        if (updatedOpenApps.length > 0) {
+          // Find the app with the highest z-index among the remaining ones to activate next.
+          const nextActiveApp = updatedOpenApps.reduce((prev, current) =>
+            prev.zIndex > current.zIndex ? prev : current,
+          );
+          setActiveAppInstanceId(nextActiveApp.instanceId);
+        } else {
+          // No apps left, so no active app.
+          setActiveAppInstanceId(null);
+        }
       }
     },
-    [activeAppInstanceId, openApps],
+    [openApps, activeAppInstanceId],
   );
 
   const toggleMinimizeApp = useCallback(


### PR DESCRIPTION
This commit introduces a functional taskbar that displays icons for both running and pinned applications, and allows them to be managed via a right-click context menu.

It also includes fixes for three follow-up bugs:
1. Default-pinned apps could not be unpinned.
2. Pinned-but-closed apps would not launch on click.
3. An app could not be re-opened after being closed, due to a stale state bug.

Key changes:
- Adds robust state management for pinned applications to `useWindowManager`, with persistence to `localStorage`. The user's choices are now the source of truth after the initial run.
- Implements a right-click context menu for taskbar icons with options to Maximize, Minimize, Close, and Pin/Unpin applications.
- Creates a new modular structure for taskbar context menu actions under `window/components/taskbar/right-click/`.
- Restores the taskbar icon click-handling logic to `App.tsx` to resolve a stability regression.
- Refactors the `closeApp` function to correctly handle state updates and prevent stale state.
- Fixes an initial bug in `Taskbar.tsx` where open applications were not being displayed.
- Clarifies application type definitions in `AppContext.tsx` to improve type safety.