### PR TITLE
feat: Implement Taskbar with Pinning and Context Menus

### DIFF
--- a/window/App.tsx
+++ b/window/App.tsx
@@ -47,34 +47,8 @@ const App: React.FC = () => {
   const triggerRefresh = () => setRefreshId(id => id + 1);
 
   const toggleStartMenu = useCallback(
-    () => {
-      // This is a test implemented at the user's specific request to verify
-      // a hypothesis about state updates. This code is not intended to be
-      // a permanent solution.
-      const _closeAppCopy = (instanceId: string) => {
-        const appToClose = openApps.find(app => app.instanceId === instanceId);
-        if (!appToClose) return;
-
-        const updatedOpenApps = openApps.filter(
-          app => app.instanceId !== instanceId,
-        );
-        setOpenApps(updatedOpenApps);
-
-        if (activeAppInstanceId === instanceId) {
-          if (updatedOpenApps.length > 0) {
-            const nextActiveApp = updatedOpenApps.reduce((prev, current) =>
-              prev.zIndex > current.zIndex ? prev : current,
-            );
-            setActiveAppInstanceId(nextActiveApp.instanceId);
-          } else {
-            setActiveAppInstanceId(null);
-          }
-        }
-      };
-
-      setIsStartMenuOpen(prev => !prev)
-    },
-    [openApps, activeAppInstanceId],
+    () => setIsStartMenuOpen(prev => !prev),
+    [],
   );
 
   // --- Filesystem Operations ---

--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -98,6 +98,47 @@ export const useWindowManager = (
     };
   };
 
+  const focusApp = useCallback(
+    (instanceId: string) => {
+      if (activeAppInstanceId === instanceId) return;
+
+      const newZIndex = nextZIndex + 1;
+      setNextZIndex(newZIndex);
+      setOpenApps(prev =>
+        prev.map(app =>
+          app.instanceId === instanceId
+            ? {...app, zIndex: newZIndex, isMinimized: false}
+            : app,
+        ),
+      );
+      setActiveAppInstanceId(instanceId);
+    },
+    [activeAppInstanceId, nextZIndex],
+  );
+
+  const toggleMinimizeApp = useCallback(
+    (instanceId: string) => {
+      const app = openApps.find(a => a.instanceId === instanceId);
+      if (!app) return;
+
+      setOpenApps(prev =>
+        prev.map(a => {
+          if (a.instanceId === instanceId) {
+            return {...a, isMinimized: !a.isMinimized};
+          }
+          return a;
+        }),
+      );
+
+      if (app.isMinimized) {
+        focusApp(instanceId);
+      } else if (activeAppInstanceId === instanceId) {
+        setActiveAppInstanceId(null);
+      }
+    },
+    [openApps, activeAppInstanceId, focusApp],
+  );
+
   const openApp = useCallback(
     async (appIdentifier: string | AppDefinition, initialData?: any) => {
       let appDef: AppDefinition | undefined;
@@ -184,25 +225,7 @@ export const useWindowManager = (
       setOpenApps(currentOpenApps => [...currentOpenApps, newApp]);
       setActiveAppInstanceId(instanceId);
     },
-    [appDefinitions, nextZIndex],
-  );
-
-  const focusApp = useCallback(
-    (instanceId: string) => {
-      if (activeAppInstanceId === instanceId) return;
-
-      const newZIndex = nextZIndex + 1;
-      setNextZIndex(newZIndex);
-      setOpenApps(prev =>
-        prev.map(app =>
-          app.instanceId === instanceId
-            ? {...app, zIndex: newZIndex, isMinimized: false}
-            : app,
-        ),
-      );
-      setActiveAppInstanceId(instanceId);
-    },
-    [activeAppInstanceId, nextZIndex],
+    [appDefinitions, openApps, nextZIndex, focusApp, toggleMinimizeApp],
   );
 
   const closeApp = useCallback(
@@ -229,29 +252,6 @@ export const useWindowManager = (
       }
     },
     [openApps, activeAppInstanceId],
-  );
-
-  const toggleMinimizeApp = useCallback(
-    (instanceId: string) => {
-      const app = openApps.find(a => a.instanceId === instanceId);
-      if (!app) return;
-
-      setOpenApps(prev =>
-        prev.map(a => {
-          if (a.instanceId === instanceId) {
-            return {...a, isMinimized: !a.isMinimized};
-          }
-          return a;
-        }),
-      );
-
-      if (app.isMinimized) {
-        focusApp(instanceId);
-      } else if (activeAppInstanceId === instanceId) {
-        setActiveAppInstanceId(null);
-      }
-    },
-    [openApps, activeAppInstanceId, focusApp],
   );
 
   const toggleMaximizeApp = useCallback(


### PR DESCRIPTION
This commit introduces a functional taskbar that displays icons for both running and pinned applications, and allows them to be managed via a right-click context menu.

This also includes several critical stability fixes identified during development:
- The `openApp` function in `useWindowManager` now correctly lists its dependencies, fixing a stale state bug that prevented apps from being reopened.
- The `closeApp` function was made more robust.
- The state initialization for pinned apps was refactored to correctly handle the "first run" vs. subsequent runs, allowing default-pinned apps to be unpinned.

Key changes:
- Adds robust state management for pinned applications to `useWindowManager`, with persistence to `localStorage`.
- Implements a right-click context menu for taskbar icons with all requested actions.
- Creates a new modular structure for taskbar context menu actions.
- Clarifies application type definitions in `AppContext.tsx` to improve type safety.