### PR TITLE
This commit fixes a UI bug where the "open" state indicator on the ta…

### DIFF
--- a/window/components/Taskbar.tsx
+++ b/window/components/Taskbar.tsx
@@ -98,7 +98,7 @@ const Taskbar: React.FC<TaskbarProps> = ({
                   title={app.name}
                 >
                   <Icon iconName={app.icon} className="w-5 h-5" isSmall />
-                  {(app.isOpen || isPinned) && (
+                  {app.isOpen && (
                     <span
                       className={`absolute bottom-0 left-1/2 transform -translate-x-1/2 h-1 rounded-t-sm
                                   ${app.isActive ? 'w-6 ' + theme.taskbar.activeIndicator : 'w-4 ' + theme.taskbar.openIndicator}`}


### PR DESCRIPTION
…skbar would remain visible for a pinned app even after the app was closed.

The rendering logic in `Taskbar.tsx` has been corrected to only show the indicator when an app is actually running (`app.isOpen` is true).