### PR TITLE
This commit fixes a bug where the 'Open' and 'Create shortcut' action…

### DIFF
--- a/window/components/ContextMenu.tsx
+++ b/window/components/ContextMenu.tsx
@@ -41,11 +41,10 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [onClose, isSubMenu]);
 
-  const handleItemClick = async (onClick: () => void) => {
-    // Close the menu immediately to prevent UI lag or race conditions
-    onClose();
-    // Await the action to ensure it completes, even if it's async
-    await onClick();
+  const handleItemClick = (onClick: () => void) => {
+    // The responsibility of closing the menu is now on the caller,
+    // which defines the onClick handler. This prevents race conditions.
+    onClick();
   };
 
   const handleSubMenuEnter = (index: number) => {
@@ -126,7 +125,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
         return (
           <button
             key={index}
-            onClick={() => item.onClick && handleItemClick(item.onClick)}
+            onClick={() => handleItemClick(item.onClick)}
             disabled={item.disabled}
             className="w-full text-left px-3 py-1.5 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-sm flex items-center"
           >

--- a/window/components/StartMenu.tsx
+++ b/window/components/StartMenu.tsx
@@ -65,12 +65,18 @@ const StartMenu: React.FC<StartMenuProps> = ({onOpenApp, onClose}) => {
         {
           type: 'item',
           label: 'Open',
-          onClick: () => onOpenApp(contextMenu.app),
+          onClick: () => {
+            onOpenApp(contextMenu.app);
+            setContextMenu(null);
+          },
         },
         {
           type: 'item',
           label: 'Create shortcut',
-          onClick: () => handleCreateShortcut(contextMenu.app),
+          onClick: async () => {
+            await handleCreateShortcut(contextMenu.app);
+            setContextMenu(null);
+          },
         },
       ]
     : [];


### PR DESCRIPTION
…s in the Start Menu's right-click context menu would not execute.

The responsibility for closing the menu has been moved from the `ContextMenu` component to the `onClick` handlers in the `StartMenu` component. This ensures that the menu-closing logic does not interrupt the execution of the primary action, especially for asynchronous operations like creating a file.