### PR TITLE
This commit introduces two major new features: "Create Shortcut" and …

### DIFF
--- a/window/components/ContextMenu.tsx
+++ b/window/components/ContextMenu.tsx
@@ -39,11 +39,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({x, y, items, onClose}) => {
       ref={menuRef}
       style={{top: finalY, left: finalX}}
       className="fixed bg-black/80 backdrop-blur-xl border border-zinc-700 rounded-md shadow-lg py-1.5 w-48 text-sm text-zinc-100 z-[60] animate-fade-in-fast"
-      onClick={e => {
-        e.stopPropagation(); // Prevent clicks inside menu from bubbling up to a dismiss handler
-        onClose(); // Close on any item click
-      }}
-      onContextMenu={e => e.preventDefault()} // Prevent native context menu on our custom one
+      // Stop propagation to prevent the 'outside click' handler from firing
+      onClick={e => e.stopPropagation()}
+      onContextMenu={e => e.preventDefault()}
     >
       {items.map((item, index) => {
         if (item.type === 'separator') {
@@ -52,7 +50,10 @@ const ContextMenu: React.FC<ContextMenuProps> = ({x, y, items, onClose}) => {
         return (
           <button
             key={index}
-            onClick={item.onClick}
+            onClick={() => {
+              item.onClick();
+              onClose();
+            }}
             disabled={item.disabled}
             className="w-full text-left px-3 py-1.5 hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed rounded-sm flex items-center"
           >


### PR DESCRIPTION
…a file association framework for "Open With", and fixes related bugs.

**Create Shortcut:**
- Users can now right-click on any application in the Start Menu and select "Create shortcut".
- This action creates a `.app` file on the Desktop, which acts as a shortcut to the original application.

**"Open With" Framework:**
- A new `fileAssociationService` has been created to manage which applications can open specific file extensions.
- Applications can now declare the file types they support in their definition.
- The file context menu now includes an "Open with" sub-menu, dynamically showing all compatible applications for the selected file.
- Double-click logic has been refactored to use this service to open files with their default associated app.

**Bug Fixes:**
- Corrected an event handling bug in `ContextMenu.tsx` that prevented menu actions from firing.
- Fixed a caching bug in `getAppDefinitions` that prevented the "Open With" menu from populating correctly.