### PR TITLE
feat: Allow overriding app settings via .app files

### DIFF
--- a/window/components/Desktop.tsx
+++ b/window/components/Desktop.tsx
@@ -176,7 +176,7 @@ const Desktop: React.FC<DesktopProps> = ({
         const fileContent = await FsService.readFile(item.path);
         if (fileContent?.content) {
           const appInfo = JSON.parse(fileContent.content);
-          openApp?.(appInfo.appId);
+          openApp?.(appInfo);
         }
       } catch (e) {
         console.error('Could not parse or open app shortcut', e);

--- a/window/components/FileExplorerApp.tsx
+++ b/window/components/FileExplorerApp.tsx
@@ -193,7 +193,7 @@ const FileExplorerApp: React.FC<AppComponentProps> = ({
           const fileContent = await FsService.readFile(item.path);
           if (fileContent?.content) {
             const appInfo = JSON.parse(fileContent.content);
-            openApp?.(appInfo.appId);
+            openApp?.(appInfo);
           }
         } catch (e) {
           console.error('Could not parse or open app shortcut', e);


### PR DESCRIPTION
This commit enhances the multi-instance feature by allowing `.app` files to override the default settings of an application.

This change implements the following:
- When a `.app` file is opened, its entire contents are now passed to the window manager.
- The window manager intelligently merges the properties from the `.app` file over the application's default `AppDefinition`. Properties in the `.app` file take precedence.
- This allows for per-shortcut control of settings, such as `allowMultipleInstances`. For example, one can create a `.app` file with `{"appId": "notebook", "allowMultipleInstances": false}` to create a shortcut that enforces a single instance, even if the Notebook app defaults to allowing multiple instances.