### PR TITLE
fix(wm): Correctly handle opening apps from Start Menu

### DIFF
--- a/window/hooks/useWindowManager.ts
+++ b/window/hooks/useWindowManager.ts
@@ -72,10 +72,17 @@ export const useWindowManager = (
       if (typeof appIdentifier === 'string') {
         baseAppDef = appDefinitions.find(app => app.id === appIdentifier);
       } else {
-        // It's an object, likely from a .app file. It must have an appId property.
         const appInfo = appIdentifier as any;
+        // Case 1: From a .app file, which has 'appId'
         if (appInfo.appId) {
           baseAppDef = appDefinitions.find(app => app.id === appInfo.appId);
+          appOverrides = appInfo;
+        }
+        // Case 2: From a direct AppDefinition object, which has 'id'
+        else if (appInfo.id) {
+          baseAppDef = appDefinitions.find(app => app.id === appInfo.id);
+          // When passed a full AppDefinition, there are no overrides,
+          // we're just using the definition itself. But we merge to ensure consistency.
           appOverrides = appInfo;
         }
       }
@@ -89,10 +96,10 @@ export const useWindowManager = (
         return;
       }
 
-      // Merge the base definition with any overrides from the .app file
+      // Merge the base definition with any overrides.
       const appDef: AppDefinition = {...baseAppDef, ...appOverrides};
 
-      if (!appDef) {
+      if (!appDef.id) {
         const id =
           typeof appIdentifier === 'string'
             ? appIdentifier


### PR DESCRIPTION
This commit fixes a bug where left-clicking an app in the "All Apps" list would fail.

The root cause was that the `openApp` function in `useWindowManager` did not correctly handle being passed a full `AppDefinition` object, which has an `id` property. It was only checking for an `appId` property, which is used by `.app` file shortcuts.

The `openApp` function has been refactored to correctly identify the application's ID whether it's called with a string, a file shortcut object, or a full application definition object. This resolves the error and makes the left-click functionality in the Start Menu work as expected.