### PR TITLE
docs: Add AI-readable guides for UI and App architecture

### DIFF
--- a/DESKTOP_AND_UI_GUIDE.md
+++ b/DESKTOP_AND_UI_GUIDE.md
@@ -1,0 +1,61 @@
+# AI Guide: Desktop, Taskbar, and Context Menus
+
+This document explains the architecture of the core user interface shell components.
+
+## 1. Overview
+
+The main UI shell of the operating system is composed of three key components: the Desktop, the Taskbar, and the Context Menu system. These components work together to provide the core user experience. The primary logic for these is located in the `window/components/` directory.
+
+---
+
+## 2. The Desktop
+
+The Desktop is the main background and icon grid area.
+
+-   **Key File:** `window/components/Desktop.tsx`
+-   **Purpose:**
+    -   Renders the desktop wallpaper.
+    -   Fetches and displays icons for files and folders located in the `/Desktop` directory of the virtual filesystem.
+    -   Manages icon layout, drag-and-drop positioning, and selection.
+-   **Core Logic:**
+    -   **File Loading:** Uses `filesystemService.listDirectory('/Desktop')` to get the items to display.
+    -   **Opening Items:** The `handleDoubleClick` function is called when an icon is double-clicked. It contains logic to open folders, `.app` files, and other file types.
+    -   **Context Menu:** The `handleIconContextMenu` function is called on right-click. It uses the `buildContextMenu` utility to generate the appropriate menu.
+-   **How to Modify:**
+    -   To change the **appearance** or **layout** of desktop icons, edit the JSX within this file.
+    -   To change the **behavior** of double-clicking or right-clicking icons, modify the `handleDoubleClick` and `handleIconContextMenu` functions respectively.
+
+---
+
+## 3. The Taskbar
+
+The Taskbar displays the Start button and icons for pinned and currently running applications.
+
+-   **Key File:** `window/components/Taskbar.tsx`
+-   **Purpose:**
+    -   Provide a persistent UI element for launching apps and managing open windows.
+-   **Core Logic:**
+    -   **Data Source:** The Taskbar is a "dumb" component that primarily renders data given to it. The logic for *which* applications to show is located in the `useWindowManager.ts` hook. This hook produces the `taskbarApps` array.
+    -   **Rendering:** The `Taskbar.tsx` component maps over the `taskbarApps` array to render the individual buttons. It contains the logic for what happens when you click an icon (e.g., open, minimize, focus).
+    -   **Multi-instance Display:** The `useWindowManager.ts` hook ensures that every open window gets its own entry in the `taskbarApps` array, so the taskbar will render a separate icon for each window.
+-   **How to Modify:**
+    -   To change the **look and feel** of the taskbar or its buttons, edit `Taskbar.tsx`.
+    -   To change the **logic for what appears on the taskbar** (e.g., how apps are grouped or ordered), you must modify the `useMemo` hook that creates the `taskbarApps` array inside `window/hooks/useWindowManager.ts`.
+
+---
+
+## 4. The Context Menu (Right-Click) System
+
+This is the system that generates right-click menus for files and folders.
+
+-   **Key Directory:** `window/components/file/right-click/`
+-   **Purpose:**
+    -   To provide a consistent, dynamic context menu for filesystem items.
+-   **Core Logic:**
+    -   **Menu Builder:** The main function is `buildContextMenu` in `index.ts`. This function receives a "context" object (containing the clicked item, current path, and various handlers) and returns an array of menu items to be rendered.
+    -   **Action Handlers:** The logic for what happens when a menu item is clicked (e.g., Delete, Rename, Create Shortcut) is separated into individual files within this directory. For example, `delete.ts` contains `handleDeleteItem`, and `shortcut.ts` contains `handleCreateShortcut`.
+-   **How to Modify:**
+    -   **To add a new option:**
+        1.  Create a new handler file (e.g., `myNewAction.ts`) with a function that performs the desired action.
+        2.  Import your new handler into `index.ts`.
+        3.  Add a new `ContextMenuItem` object to the `menuItems` array inside the `buildContextMenu` function in `index.ts`. Set its `onClick` property to call your new handler.

--- a/components/apps/AGENTS.md
+++ b/components/apps/AGENTS.md
@@ -1,0 +1,72 @@
+# AI Guide: Application Architecture and Launch Logic
+
+This document explains the different types of applications in this system and how they are launched.
+
+## 1. Overview
+
+There are three distinct types of "applications" in this operating system simulator. Understanding the difference is crucial for modification and extension.
+
+1.  **Core Internal Apps:** React components rendered within a standard window.
+2.  **Filesystem App Shortcuts:** `.app` files that act as pointers to Core Internal Apps, with potential for overriding properties.
+3.  **External Standalone Apps:** True standalone applications that run in a separate OS process.
+
+---
+
+## 2. Type 1: Core Internal Apps
+
+These are the standard applications of the OS.
+
+-   **Description:** They are React components that get rendered inside a generic `AppWindow`. They are part of the main application bundle.
+-   **Examples:** File Explorer, Notebook, Settings, About.
+-   **Definition File:** Each app has a corresponding `...App.tsx` file (e.g., `FileExplorerApp.tsx`, `NotebookApp.tsx`). The single source of truth for the app's properties is the `appDefinition` object exported from the bottom of this file.
+-   **Launch Logic:**
+    1.  An action (e.g., clicking the Start Menu icon) calls the `openApp` function from the `useWindowManager` hook, passing the app's unique `id` string (e.g., `openApp('notebook')`).
+    2.  The `useWindowManager` finds the corresponding `appDefinition` from its master list.
+    3.  It then adds a new `OpenApp` object to its state, which causes the main `App.tsx` to render a new `<AppWindow />` containing the app's component.
+-   **Associated Files:**
+    -   `window/types.ts`: Defines the `AppDefinition` interface.
+    -   `window/hooks/useWindowManager.ts`: Contains the `openApp` logic.
+    -   `window/components/AppWindow.tsx`: The generic window frame that hosts the app component.
+    -   `components/apps/index.ts`: This file aggregates all core app definitions into a single list for the window manager. **When adding a new core app, you must import its definition here.**
+
+---
+
+## 3. Type 2: Filesystem App Shortcuts (`.app` files)
+
+These are filesystem-based shortcuts that can launch any Core Internal App.
+
+-   **Description:** They are simple JSON files with a `.app` extension that live in the virtual filesystem (e.g., on the Desktop or in `/All Apps`). They primarily serve as pointers but can also be used to override default properties of an application for a specific shortcut.
+-   **Example Content:**
+    -   `{"appId": "notebook"}`
+    -   `{"appId": "notebook", "allowMultipleInstances": false}` (This would launch Notebook as a single-instance app, overriding its default behavior).
+-   **Launch Logic:**
+    1.  A user double-clicks the `.app` file in the `FileExplorer` or on the `Desktop`.
+    2.  The `openItem` (or `handleDoubleClick`) function in that component reads the JSON content of the file.
+    3.  It passes the **entire parsed JSON object** to the `openApp` function in `useWindowManager.ts`.
+    4.  `openApp` detects that it has been passed an object, not a string. It uses the `appId` from the object to find the base `AppDefinition`, and then **merges** the properties from the `.app` file object over the top of the base definition.
+    5.  This final, merged `AppDefinition` is then used to launch the window. This is how the override system works.
+-   **Associated Files:**
+    -   `window/components/FileExplorerApp.tsx`: The `openItem` function contains this logic.
+    -   `window/components/Desktop.tsx`: The `handleDoubleClick` function contains this logic.
+    -   `window/hooks/useWindowManager.ts`: The `openApp` function contains the merging logic.
+
+---
+
+## 4. Type 3: External Standalone Apps
+
+These are separate, self-contained applications that run in their own OS process.
+
+-   **Description:** These are typically more complex applications that have their own backend or require isolation from the main OS shell. They are not just React components.
+-   **Example:** `Chrome5`
+-   **Definition File:** Located in their own subdirectories within `components/apps/`. They must have their own `package.json` and a `main.js` that serves as the entry point for the new Electron process.
+-   **Launch Logic:**
+    1.  The `appDefinition` for these apps must have `isExternal: true` and an `externalPath` property pointing to its entry script.
+    2.  The `openApp` function in `useWindowManager.ts` detects the `isExternal` flag.
+    3.  Instead of creating an `AppWindow`, it calls an API to launch a new process.
+        -   In a full Electron environment, this is `window.electronAPI.launchExternalApp`.
+        -   In a web-based environment, this is a `fetch` call to the `/api/launch` endpoint on the backend server.
+    4.  The backend then spawns a new Electron process using the `externalPath`.
+-   **Associated Files:**
+    -   `main/launcher.js`: Contains the server-side logic for spawning the new Electron process.
+    -   `main/api.js`: Exposes the `/api/launch` endpoint.
+    -   `preload.js`: Exposes the `launchExternalApp` function to the Electron renderer process.


### PR DESCRIPTION
This commit adds two new markdown files containing documentation aimed at AI agents and developers to explain core parts of the system architecture.

1.  `DESKTOP_AND_UI_GUIDE.md`: Added to the root directory. This file explains the architecture of the UI shell, including the Desktop, Taskbar, and Context Menu systems. It details key files and procedures for modification.

2.  `components/apps/AGENTS.md`: Added to the `components/apps/` directory. This file explains the three different types of applications (Core Internal, Filesystem Shortcuts, External Standalone) and their respective launch logic.