### PR TITLE
feat: Add Restart functionality to Start Menu

### DIFF
--- a/main/ipc.js
+++ b/main/ipc.js
@@ -1,7 +1,12 @@
-const {ipcMain, session} = require('electron');
+const {ipcMain, session, app} = require('electron');
 const {launchExternalAppByPath} = require('./launcher');
 
 function initializeIpcHandlers() {
+  ipcMain.handle('restart-app', () => {
+    app.relaunch();
+    app.quit();
+  });
+
   ipcMain.handle('app:launchExternal', (event, relativeAppPath, args) => {
     return launchExternalAppByPath(relativeAppPath, args);
   });

--- a/preload.js
+++ b/preload.js
@@ -13,4 +13,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('session:set-proxy', partition, proxyConfig),
   clearProxyForSession: partition =>
     ipcRenderer.invoke('session:clear-proxy', partition),
+  restartApp: () => ipcRenderer.invoke('restart-app'),
 });

--- a/window/types.ts
+++ b/window/types.ts
@@ -10,6 +10,7 @@ export interface IElectronAPI {
     proxyConfig: {proxyRules: string},
   ) => Promise<void>;
   clearProxyForSession: (partition: string) => Promise<void>;
+  restartApp: () => void;
 }
 
 declare global {


### PR DESCRIPTION
This commit implements a restart button in the Start Menu's power options.

This was implemented by:
- Adding a `restartApp` function to the `IElectronAPI` interface, `preload.js` bridge, and `main/ipc.js` handler.
- The IPC handler uses `app.relaunch()` and `app.quit()` to safely restart the Electron application.
- The `StartMenu.tsx` component was updated with a new state and UI to show a power menu with a "Restart" button when the power icon is clicked.