### PR TITLE
fix(ui): Add missing useEffect import in StartMenu

### DIFF
--- a/window/components/StartMenu.tsx
+++ b/window/components/StartMenu.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useMemo, useContext, useRef} from 'react';
+import React, {useState, useMemo, useContext, useRef, useEffect} from 'react';
 import {AppContext} from '../contexts/AppContext';
 import Icon from './icon';
 import {useTheme} from '../theme';


### PR DESCRIPTION
This commit fixes a crash that occurred when opening the Start Menu.

The crash was caused by a `ReferenceError: useEffect is not defined` because the `useEffect` hook was used without being imported from React. This was introduced during the implementation of the power menu feature.

This commit adds the missing `useEffect` to the import statement in `window/components/StartMenu.tsx`, resolving the crash.