### PR TITLE
fix(core): Correctly handle child processes on restart

### DIFF
--- a/main/launcher.js
+++ b/main/launcher.js
@@ -19,7 +19,6 @@ function launchExternalAppByPath(relativeAppPath, args = []) {
     );
 
     const child = spawn(process.execPath, spawnArgs, {
-      detached: true,
       stdio: 'pipe',
       // Provide the NODE_PATH to ensure the child can find the parent's `electron` module.
       // This is critical for preventing "Cannot find module" errors.
@@ -53,7 +52,6 @@ function launchExternalAppByPath(relativeAppPath, args = []) {
     });
 
     add(child); // Add to tracking
-    child.unref();
 
     return true;
   } catch (error) {


### PR DESCRIPTION
This commit fixes a bug where the application would not restart correctly. The issue was caused by a logical conflict between the graceful shutdown procedure and the way child processes were launched.

The `child.unref()` call and `detached: true` option in `main/launcher.js` caused the parent process to not wait for its children, which conflicted with the new logic in the IPC handler that explicitly waits for children to terminate.

This commit resolves the issue by removing the `unref()` call and `detached` option, ensuring that child processes are correctly tracked and waited for during a restart.